### PR TITLE
upgrade compute engine api, gcelib, hadoop and tune config for large clusters

### DIFF
--- a/cfg.py
+++ b/cfg.py
@@ -69,7 +69,8 @@ class Config(object):
     # Hadoop details
 
     self.hadoop_url = 'archive.apache.org/dist/hadoop/common'
-    self.hadoop_version = '1.0.3'
+    # Use latest stable version of Hadoop, as of 2/4/2013.
+    self.hadoop_version = '1.1.1'
     self.hadoop_fn = 'hadoop-{0}'.format(self.hadoop_version)
     self.hadoop_bin = '/home/hadoop/hadoop/bin/'
     # This is where ephemeral disk gets mounted. Note this location is hardcoded

--- a/coordinator/hadoop_cluster.py
+++ b/coordinator/hadoop_cluster.py
@@ -152,22 +152,26 @@ class HadoopCluster(object):
       scope = cfg.rw_storage_scope
     else:
       scope = cfg.ro_storage_scope
-    resp = util.api.insert_instance(
-        name=name, zone=cfg.zone,
-        machineType=cfg.machine_type, image=cfg.image,
-        serviceAccounts=gce_shortcuts.service_accounts([scope]),
-        disks=disks,
-        metadata=gce_shortcuts.metadata({
-            'gs_bucket': cfg.gs_bucket,
-            'snitch-tarball.tgz': cfg.gs_snitch_tarball,
-            'startup-script': open('start_setup.sh').read(),
-            'bootstrap.sh': open('hadoop/bootstrap.sh').read(),
-            'snitch.py': open(snitch).read()
-        }),
-        networkInterfaces=network,
-        blocking=True
-    )
-    return not 'error' in resp
+    try:
+      resp = util.api.insert_instance(
+          name=name, zone=cfg.zone,
+          machineType=cfg.machine_type, image=cfg.image,
+          serviceAccounts=gce_shortcuts.service_accounts([scope]),
+          disks=disks,
+          metadata=gce_shortcuts.metadata({
+              'gs_bucket': cfg.gs_bucket,
+              'snitch-tarball_tgz': cfg.gs_snitch_tarball,
+              'startup-script': open('start_setup.sh').read(),
+              'bootstrap_sh': open('hadoop/bootstrap.sh').read(),
+              'snitch_py': open(snitch).read()
+          }),
+          networkInterfaces=network,
+          blocking=True
+      )
+    except:
+      logging.info('exception thrown while inserting instance ' + name)
+      return False
+    return True
 
   def new_slave_names(self, num):
     # Callers should assume these slaves will be created

--- a/coordinator/hadoop_cluster.py
+++ b/coordinator/hadoop_cluster.py
@@ -23,6 +23,7 @@ import threading
 import time
 
 from cfg import cfg
+from gcelib import gce
 import gcelib.shortcuts as gce_shortcuts
 import util
 from util import InstanceState
@@ -159,6 +160,7 @@ class HadoopCluster(object):
           serviceAccounts=gce_shortcuts.service_accounts([scope]),
           disks=disks,
           metadata=gce_shortcuts.metadata({
+              # Key modified to avoid dots, which are disallowed in v1beta13.
               'gs_bucket': cfg.gs_bucket,
               'snitch-tarball_tgz': cfg.gs_snitch_tarball,
               'startup-script': open('start_setup.sh').read(),
@@ -168,9 +170,10 @@ class HadoopCluster(object):
           networkInterfaces=network,
           blocking=True
       )
-    except:
-      logging.info('exception thrown while inserting instance ' + name)
-      return False
+    except gce.GceError as e:
+      logging.info('GCE exception inserting instance ' + name + ': ' + str(e))
+    except Exception as e:
+      logging.info('exception inserting instance ' + name + ': ' + str(e))
     return True
 
   def new_slave_names(self, num):

--- a/hadoop/bootstrap.sh
+++ b/hadoop/bootstrap.sh
@@ -50,7 +50,8 @@ tar xzf snitch-tarball.tgz
 
 # Set up the REST agent
 sudo easy_install -H None -f bottle_install -U bottle
-wget ${MD}/snitch.py
+wget ${MD}/snitch_py
+mv snitch_py snitch.py
 chmod +x snitch.py
 
 # Setup Hadoop and start snitch

--- a/hadoop/conf/core-site.xml
+++ b/hadoop/conf/core-site.xml
@@ -8,4 +8,20 @@
     <name>fs.default.name</name>
     <value>hdfs://hadoop-namenode:9000</value>
   </property>
+  <property>
+    <name>fs.inmemory.size.mb</name>
+    <value>200</value>
+  </property>
+  <property>
+    <name>io.sort.factor</name>
+    <value>100</value>
+  </property>
+  <property>
+    <name>io.sort.mb</name>
+    <value>200</value>
+  </property>
+  <property>
+    <name>io.file.buffer.size</name>
+    <value>131072</value>
+  </property>
 </configuration>

--- a/hadoop/conf/hdfs-site.xml
+++ b/hadoop/conf/hdfs-site.xml
@@ -7,10 +7,18 @@
 <configuration>
   <property>
     <name>dfs.replication</name>
-    <value>3</value>
+    <value>1</value>
   </property>
   <property>
     <name>dfs.data.dir</name>
     <value>/mnt/hadoop/dfs</value>
+  </property>
+  <property>
+    <name>dfs.block.size</name>
+    <value>134217728</value>
+  </property>
+  <property>
+    <name>dfs.namenode.handler.count</name>
+    <value>40</value>
   </property>
 </configuration>

--- a/hadoop/conf/mapred-site.xml
+++ b/hadoop/conf/mapred-site.xml
@@ -12,4 +12,16 @@
     <name>mapred.local.dir</name>
     <value>/mnt/hadoop/mapred</value>
   </property>
+  <property>
+    <name>mapred.child.java.opts</name>
+    <value>-Xmx1024m</value>
+  </property>
+  <property>
+    <name>mapred.reduce.parallel.copies</name>
+    <value>20</value>
+  </property>
+  <property>
+    <name>mapred.reduce.slowstart.completed.maps</name>
+    <value>.5</value>
+  </property>
 </configuration>

--- a/one_time_setup.sh
+++ b/one_time_setup.sh
@@ -17,6 +17,9 @@
 # If you need to get back to a clean state after running it, run:
 # rm -rf gcelib* tools/cfg.py tools/util.py tools/gcelib secret java/target hadoop-tools.jar *.pyc tools/*.pyc
 
+# Latest version of gcelib.
+GCELIB_VERS=0.3.0
+
 set -e
 
 if [ ! -f one_time_setup.sh ]; then
@@ -28,11 +31,11 @@ chmod +x tools/*.py
 chmod -x tools/common.py
 
 echo "Setting up gcelib..."
-wget --quiet http://google-compute-engine-tools.googlecode.com/files/gcelib-0.1.0.tar.gz
-tar xzf gcelib-0.1.0.tar.gz
-rm -f gcelib-0.1.0.tar.gz
-mv gcelib-0.1.0/gcelib real_gcelib
-rm -rf gcelib-0.1.0
+wget --quiet http://google-compute-engine-tools.googlecode.com/files/gcelib-$GCELIB_VERS.tar.gz
+tar xzf gcelib-$GCELIB_VERS.tar.gz
+rm -f gcelib-$GCELIB_VERS.tar.gz
+mv gcelib-$GCELIB_VERS/gcelib real_gcelib
+rm -rf gcelib-$GCELIB_VERS
 mv real_gcelib gcelib
 ln -s ../gcelib tools/gcelib
 ./tools/authorize_gce.py

--- a/start_setup.sh
+++ b/start_setup.sh
@@ -23,7 +23,7 @@ BOOTSTRAP="/home/${USERNAME}/bootstrap.sh"
 
 adduser ${USERNAME} --disabled-password --shell /bin/bash
 echo "${USERNAME} ALL=NOPASSWD: ALL" >> /etc/sudoers
-wget ${METADATA_URL}/bootstrap.sh -O ${BOOTSTRAP}
+wget ${METADATA_URL}/bootstrap_sh -O ${BOOTSTRAP}
 chown ${USERNAME} ${BOOTSTRAP}
 chmod +x ${BOOTSTRAP}
 

--- a/tools/launch_coordinator.py
+++ b/tools/launch_coordinator.py
@@ -62,7 +62,7 @@ def main():
       networkInterfaces=gce_shortcuts.network(),
       metadata=gce_shortcuts.metadata({
           'startup-script': open('start_setup.sh').read(),
-          'bootstrap.sh': open('coordinator/bootstrap.sh').read(),
+          'bootstrap_sh': open('coordinator/bootstrap.sh').read(),
           'tarball': cfg.gs_coordinators_tarball,
           'gs_bucket': cfg.gs_bucket,
           'zone': zone,

--- a/tools/launch_coordinator.py
+++ b/tools/launch_coordinator.py
@@ -61,6 +61,7 @@ def main():
                                                       cfg.rw_storage_scope]),
       networkInterfaces=gce_shortcuts.network(),
       metadata=gce_shortcuts.metadata({
+          # Key modified to avoid dots, which are disallowed in v1beta13.
           'startup-script': open('start_setup.sh').read(),
           'bootstrap_sh': open('coordinator/bootstrap.sh').read(),
           'tarball': cfg.gs_coordinators_tarball,

--- a/util.py
+++ b/util.py
@@ -31,7 +31,7 @@ import httplib2
 
 from cfg import cfg
 import gcelib.gce_util
-import gcelib.gce_v1beta12
+import gcelib.gce_v1beta13
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -59,7 +59,7 @@ def setup_api(service_account=True):
     creds = gcelib.gce_util.ServiceAccountCredentials()
   else:
     creds = gcelib.gce_util.get_credentials()
-  api = gcelib.gce_v1beta12.GoogleComputeEngine(
+  api = gcelib.gce_v1beta13.GoogleComputeEngine(
       creds, default_project=cfg.project_id,
       logging_level=logging.ERROR)
 


### PR DESCRIPTION
upgrade from gcelib 0.1.0 to 0.3.0
upgrade hadoop from 1.0.3 to 1.1.1
add config changes to optimize performance for large clusters
